### PR TITLE
Rename config to config.json.orig in 3.8

### DIFF
--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -30,7 +30,7 @@ RUN set -x && \
 
   mkdir /opt/mattermost/data && \
 
-  cp -f /opt/mattermost/config/config.json /opt/mattermost/config.json && \
+  cp -f /opt/mattermost/config/config.json /opt/mattermost/config.json.orig && \
 
   chown -R 1001 /opt/mattermost && \
   chmod 777 /opt/mattermost/data /opt/mattermost/logs

--- a/3.8/docker-entrypoint.sh
+++ b/3.8/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 MM_HOME=/opt/mattermost
 MM_CONFIG=${MM_HOME}/config/config.json
-MM_CONFIG_ORIG=${MM_HOME}/config.json
+MM_CONFIG_ORIG=${MM_HOME}/config.json.orig
 
 function updatejson() {
   set -o nounset


### PR DESCRIPTION
This fixes a bug where version 3.8 reads the config from /opt/mattermost/config.json before /opt/mattermost/config/config.json where we store our config